### PR TITLE
fix : v2 pagination data types

### DIFF
--- a/client/two/delegates_responses.go
+++ b/client/two/delegates_responses.go
@@ -8,8 +8,8 @@
 package two
 
 type DelegateBlocks struct {
-	Produced byte  `json:"produced,omitempty"`
-	Missed   byte  `json:"missed,omitempty"`
+	Produced uint32  `json:"produced,omitempty"`
+	Missed   uint32  `json:"missed,omitempty"`
 	Last     Block `json:"last,omitempty"`
 }
 

--- a/client/two/meta.go
+++ b/client/two/meta.go
@@ -8,9 +8,9 @@
 package two
 
 type Meta struct {
-	Count      byte   `url:"count,omitempty"`
-	PageCount  uint32   `url:"pageCount,omitempty"`
-	TotalCount uint32   `url:"totalCount,omitempty"`
+	Count      uint16   `url:"count,omitempty"`
+	PageCount  uint16   `url:"pageCount,omitempty"`
+	TotalCount uint16   `url:"totalCount,omitempty"`
 	Next       string `url:"next,omitempty"`
 	Previous   string `url:"previous,omitempty"`
 	Self       string `url:"self,omitempty"`

--- a/client/two/meta.go
+++ b/client/two/meta.go
@@ -9,8 +9,8 @@ package two
 
 type Meta struct {
 	Count      byte   `url:"count,omitempty"`
-	PageCount  byte   `url:"pageCount,omitempty"`
-	TotalCount byte   `url:"totalCount,omitempty"`
+	PageCount  uint32   `url:"pageCount,omitempty"`
+	TotalCount uint32   `url:"totalCount,omitempty"`
 	Next       string `url:"next,omitempty"`
 	Previous   string `url:"previous,omitempty"`
 	Self       string `url:"self,omitempty"`

--- a/client/two/peers_responses.go
+++ b/client/two/peers_responses.go
@@ -11,8 +11,8 @@ type Peer struct {
 	Ip      string `json:"ip,omitempty"`
 	Port    uint16 `json:"port,omitempty"`
 	Version string `json:"version,omitempty"`
-	Height  byte   `json:"height,omitempty"`
-	Status  string `json:"status,omitempty"`
+	Height  uint32 `json:"height,omitempty"`
+	Status  uint32 `json:"status,omitempty"`
 	Os      string `json:"os,omitempty"`
 	Latency byte   `json:"latency,omitempty"`
 }

--- a/client/two/peers_responses.go
+++ b/client/two/peers_responses.go
@@ -12,7 +12,7 @@ type Peer struct {
 	Port    uint16 `json:"port,omitempty"`
 	Version string `json:"version,omitempty"`
 	Height  uint32 `json:"height,omitempty"`
-	Status  uint32 `json:"status,omitempty"`
+	Status  string `json:"status,omitempty"`
 	Os      string `json:"os,omitempty"`
 	Latency byte   `json:"latency,omitempty"`
 }


### PR DESCRIPTION
## Proposed changes

Fixed the pagination by modifying the Meta structure, before that, treating the results of something like 

```go
query := &two.Pagination{Limit: 10}
responseStruct, _, err := client.Blocks.List(context.Background(), query)
``` 

would have thrown the following error

```go 
json: cannot unmarshal number 82864 into Go struct field Meta.PageCount of type uint8 
``` 

and trying to get the content of ```responseStruct ``` would have resulted into 

```go
...
spew.Dump(responseStruct)
(*two.Blocks)(<nil>)
```

Edit : Had to change some values inside delegates_responses and peers_responses too related to this same problem.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes