### PR TITLE
feat: add Time() method to timestamp

### DIFF
--- a/client/transactions_responses.go
+++ b/client/transactions_responses.go
@@ -7,6 +7,10 @@
 
 package client
 
+import (
+	"time"
+)
+
 type Transaction struct {
 	Address       string            `json:"address,omitempty"`
 	Id            string            `json:"id,omitempty"`
@@ -44,6 +48,12 @@ type Timestamp struct {
 	Epoch int32  `json:"epoch,omitempty"`
 	Unix  int32  `json:"unix,omitempty"`
 	Human string `json:"human,omitempty"`
+}
+
+// Time parses the unix value of the timestamp and returns as time.Time object with
+// location as local.
+func (t Timestamp) Time() time.Time {
+	return time.Unix(int64(t.Unix), 0)
 }
 
 type CreateTransaction struct {


### PR DESCRIPTION
Added a convenience method to timestamp to convert it to native golang time objects.

## Proposed changes
Using native golang time objects is more idiomatic and safer, as it is quite easy to mess up timezones and other calculations when dealing with raw unix timestamps

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist

- [ ] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation // this 404s
- [X ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X ] I have added necessary documentation (if appropriate)
<!--

## Further comments
The change is incredibly small, I basically added a single line, which calls a stdlib function.
