### PR TITLE
fix: switch body and queryString parameters inside the create method

### DIFF
--- a/client/transactions.go
+++ b/client/transactions.go
@@ -32,7 +32,7 @@ func (s *TransactionsService) List(ctx context.Context, query *Pagination) (*Tra
 // Create a new transaction.
 func (s *TransactionsService) Create(ctx context.Context, body *CreateTransactionRequest) (*CreateTransaction, *http.Response, error) {
 	var responseStruct *CreateTransaction
-	resp, err := s.client.SendRequest(ctx, "POST", "transactions", body, nil, &responseStruct)
+	resp, err := s.client.SendRequest(ctx, "POST", "transactions", nil, body, &responseStruct)
 
 	if err != nil {
 		return nil, resp, err


### PR DESCRIPTION
## Proposed changes

Had to switch these two parameters, creation of a transaction wasn't working because of that.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes